### PR TITLE
feat(CaseSaga): Support saga type

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ const slice = createSliceSaga({
     *action2 (action: PayloadAction<number>) {
       yield console.log("ok2", action.payload);
     },
+    action3: {
+        sagaType: SagaType.TakeLatest,
+        *fn(action: PayloadAction<boolean>) {
+            yield console.log("ok3", action.payload);
+        },
+    }
   },
   sagaType: SagaType.Watch,
 });

--- a/src/createSliceSaga.ts
+++ b/src/createSliceSaga.ts
@@ -1,11 +1,11 @@
 /* eslint-disable @typescript-eslint/ban-types */
 /* eslint-disable @typescript-eslint/no-explicit-any */
+
 import { Action, AnyAction } from 'redux';
 import {
   PayloadAction,
   PayloadActionCreator,
   ActionCreatorWithoutPayload,
-  PrepareAction,
   createAction,
   ActionCreatorWithPreparedPayload,
 } from '@reduxjs/toolkit';
@@ -31,8 +31,13 @@ export type CaseSagas<A extends Action = AnyAction> = (
   action: A,
 ) => Generator<unknown, unknown, SagaIterator>;
 
+type CustomCaseSaga = {
+  fn: CaseSagas<PayloadAction<any>>;
+  sagaType?: SagaType;
+};
+
 export type SliceCaseSagas = {
-  [K: string]: CaseSagas<PayloadAction<any>>;
+  [K: string]: CaseSagas<PayloadAction<any>> | CustomCaseSaga;
 };
 
 type ActionCreatorForCaseSagaWithPrepare<
@@ -122,11 +127,18 @@ export function getType(slice: string, actionKey: string): string {
   return `${slice}/${actionKey}`;
 }
 
+function isCustomCaseSaga(value: unknown): value is CustomCaseSaga {
+  return (
+    typeof value === 'object' &&
+    typeof (value as CustomCaseSaga).fn === 'function'
+  );
+}
+
 export function createSliceSaga<
   CaseSagas extends SliceCaseSagas,
   Name extends string = string
 >(options: CreateOptionsSliceSaga<CaseSagas, Name>): Slice<CaseSagas, Name> {
-  const { caseSagas, name, sagaType = SagaType.TakeEvery } = options;
+  const { caseSagas, name, sagaType: globalSagaType } = options;
   const caseSagasNames = Object.keys(caseSagas);
   const actionCreators: Record<
     string,
@@ -136,23 +148,36 @@ export function createSliceSaga<
 
   caseSagasNames.forEach((sagaName) => {
     const type = getType(name, sagaName);
-    let prepareCallback: PrepareAction<any> | undefined;
-    actionCreators[sagaName] = prepareCallback
-      ? createAction(type, prepareCallback)
-      : createAction(type);
 
-    sagas.push(
-      call(
-        sagaType === SagaType.Normal
-          ? caseSagas[sagaName]
-          : createSaga(sagaType, type, caseSagas[sagaName]),
-      ),
-    );
+    actionCreators[sagaName] = createAction(type);
+
+    const currentCaseSaga = caseSagas[sagaName];
+
+    let toBeCalled;
+
+    if (isCustomCaseSaga(currentCaseSaga)) {
+      toBeCalled =
+        currentCaseSaga.sagaType === SagaType.Normal
+          ? currentCaseSaga.fn
+          : createSaga(currentCaseSaga.sagaType, type, currentCaseSaga.fn);
+    } else {
+      toBeCalled =
+        globalSagaType === SagaType.Normal
+          ? currentCaseSaga
+          : createSaga(globalSagaType, type, currentCaseSaga);
+    }
+
+    sagas.push(call(toBeCalled));
   });
 
   function* saga(): SagaFunReturnType {
     yield all(sagas);
   }
 
-  return { saga, name, actions: actionCreators as any, sagaType };
+  return {
+    saga,
+    name,
+    actions: actionCreators as any,
+    sagaType: globalSagaType,
+  };
 }


### PR DESCRIPTION
# Case Saga support saga type

Issue: https://github.com/anymore1405/redux-toolkit-saga/issues/4

## Proposal

I would like to be able to specify a sagaType for one of my saga inside `caseSagas` object.

Example: 

Overriding "global" SagaType options :
```es6
createSliceSagas({
  name: 'test',
  caseSagas: {
    *withGlobalSagaType({ payload }) {
      //
    },
    withSpecificSagaType: {
      *fn({ payload }) {
        //
      },
      sagaType: SagaType.TakeEvery // any other SagaType
    }
  },
  sagaType: SagaType.TakeLatest
)
```



